### PR TITLE
Use fabsf to ensure no double promotion

### DIFF
--- a/src/dsp.cpp
+++ b/src/dsp.cpp
@@ -192,13 +192,13 @@ void sigmoid_(Eigen::MatrixXf &x, const long i_start, const long i_end,
 
 inline float fast_tanh_(const float x)
 {
-    const float ax = fabs(x);
+    const float ax = fabsf(x);
     const float x2 = x * x;
 
     return(x * (2.45550750702956f + 2.45550750702956f * ax +
         (0.893229853513558f + 0.821226666969744f * ax) * x2) /
         (2.44506634652299f + (2.44506634652299f + x2) *
-            fabs(x + 0.814642734961073f * x * ax)));
+            fabsf(x + 0.814642734961073f * x * ax)));
 }
 
 void tanh_(Eigen::MatrixXf& x)


### PR DESCRIPTION
This approach is slightly faster, as the function is meant to return a float.
I guess you imported this from some code that had `using namespace std::` where the `std::fabs` was being applied automatically..
Anyhow this more verbose approach ensures we always use the float type variant