### PR TITLE
Output fixes. patch get/state changed

### DIFF
--- a/resources/neural_amp_modeler.ttl.in
+++ b/resources/neural_amp_modeler.ttl.in
@@ -33,7 +33,13 @@
 	lv2:optionalFeature lv2:hardRTCapable;
 	lv2:extensionData work:interface, state:interface;
 
-	rdfs:comment "An LV2 implementation of Neural Amp Modeler";
+	rdfs:comment """
+An LV2 implementation of Neural Amp Modeler.
+
+NAM accepts Neural Amp Modeler .nam files.
+
+A large collection of .nam files is available at https://tonehunt.org/
+""";
 
 	patch:writable <@NAM_LV2_ID@#model>;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,8 +45,10 @@ if (MSVC)
 	)
 else()
 	target_compile_options(neural_amp_modeler PRIVATE
-		-Wall -Wextra -Wpedantic -Wstrict-aliasing -Wunreachable-code -Weffc++ -Wno-unused-parameter
-		"$<$<CONFIG:DEBUG>:-Og;-ggdb;-Werror>"
+		-Wall 
+		# -Wpedantic -Wextra -Wstrict-aliasing -Wunreachable-code -Weffc++ -Wno-unused-parameter
+		"$<$<CONFIG:DEBUG>:-Og;-ggdb>"
+		"$<$<CONFIG:RELWITHDEBINFO>:-Ofast>"
 		"$<$<CONFIG:RELEASE>:-Ofast>"
 	)
 endif()

--- a/src/nam_plugin.h
+++ b/src/nam_plugin.h
@@ -17,6 +17,7 @@
 #include <lv2/patch/patch.h>
 #include <lv2/worker/worker.h>
 #include <lv2/state/state.h>
+#include <lv2/units/units.h>
 
 #include "dsp.h"
 
@@ -55,6 +56,7 @@ namespace NAM {
 		std::unique_ptr<::DSP> currentModel;
 		std::unique_ptr<::DSP> stagedModel;
 		std::unique_ptr<::DSP> deleteModel;
+		bool stateChanged = false;
 
 		std::string currentModelPath;
 		std::string stagedModelPath;
@@ -67,7 +69,8 @@ namespace NAM {
 		bool initialize(double rate, const LV2_Feature* const* features) noexcept;
 		void process(uint32_t n_samples) noexcept;
 		
-		LV2_Atom_Forge_Ref write_set_patch(std::string filename);
+		void write_set_patch(std::string filename);
+		void write_state_changed();
 
 		static LV2_Worker_Status work(LV2_Handle instance, LV2_Worker_Respond_Function respond, LV2_Worker_Respond_Handle handle,
 			uint32_t size, const void* data);
@@ -79,6 +82,8 @@ namespace NAM {
 			const LV2_Feature* const* features);
 
 	private:
+		static constexpr size_t MAX_FILE_NAME = 1024;
+
 		struct URIs {
 			LV2_URID atom_Object;
 			LV2_URID atom_Float;
@@ -89,12 +94,15 @@ namespace NAM {
 			LV2_URID patch_Get;
 			LV2_URID patch_property;
 			LV2_URID patch_value;
+			LV2_URID state_StateChanged;
+			LV2_URID units_frame;
 			LV2_URID model_Path;
 		};
 
 		URIs uris = {};
 
 		LV2_Atom_Forge atom_forge = {};
+		LV2_Atom_Forge_Frame sequence_frame;
 
 		std::vector<double> dblData;
 


### PR DESCRIPTION
- Prepare notification sequence so that plugin can write patch_get and state_statechanged objects.
- Send LV2_State__StateChanged messages.
- Don't send an error when path is empty (because hosts will show an alert). 
- Reduced warnings to workable level in non-deps build
- Fixed Debug and RELWITHDEBINFO builds.

fyi, ~55% CPU use (very high) on a Raspbery Pi 4, but results are excellent!

Tested with [PiPedal ](https://rerdavies.github.io/pipedal/)