### PR TITLE
Update neural_amp_modeler.ttl.in

### DIFF
--- a/resources/neural_amp_modeler.ttl.in
+++ b/resources/neural_amp_modeler.ttl.in
@@ -99,5 +99,5 @@ A large collection of .nam files is available at https://tonehunt.org/
 		units:unit units:db;
 	];
     state:state [
-            <@NAM_LV2_ID@#model>;
+            <@NAM_LV2_ID@#model> <empty> ;
     ].


### PR DESCRIPTION
Check it out and see if it breaks anything. This solved my issue with lilv/pipedal complaining about prefix and then not loading the plugin.