### PR TITLE
Fix install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,8 @@ add_custom_target(copy_binaries ALL
 configure_file(resources/manifest.ttl.in neural_amp_modeler.lv2/manifest.ttl)
 configure_file(resources/neural_amp_modeler.ttl.in neural_amp_modeler.lv2/neural_amp_modeler.ttl)
 
-install (DIRECTORY build/neural_amp_modeler.lv2
-       DESTINATION /usr/lib/lv2
+install (DIRECTORY ${CMAKE_BINARY_DIR}/neural_amp_modeler.lv2
+       DESTINATION lib/lv2
 )
 
 set(CPACK_GENERATOR "DEB")


### PR DESCRIPTION
Hey, thank you for creating this! <3

The changes in this PR are required for building the plugin as a Flatpak, which is what I'm currently trying to do. The 'normal' build process will not be affected in any way.

The new `DIRECTORY` line makes installation work with any build directory, not just `build`. (Flatpak builds in a `_flatpak_build` directory instead of using `build`.)

Using a relative `DESTINATION` path honors `CMAKE_INSTALL_PREFIX` instead of hardcoding it to `/usr`. (Flatpak installs into `/app/extensions/Plugins` as a prefix.)