### PR TITLE
Asynchronous updating of state for #36

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(NeuralAmpModelerLv2 VERSION 0.1.0)
+project(NeuralAmpModelerLv2 VERSION 0.1.1)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 


### PR DESCRIPTION
See Issue #36 for details. Setting currentModelPath after the load completes causes synchronization problems with state.save().