### PR TITLE
Bad-atom_forge-write-

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(NeuralAmpModelerLv2 VERSION 0.1.0)
+project(NeuralAmpModelerLv2 VERSION 0.1.1)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 

--- a/src/nam_plugin.h
+++ b/src/nam_plugin.h
@@ -118,5 +118,6 @@ namespace NAM {
 		float inputLevel = 0;
 		float outputLevel = 0;
 		int32_t maxBufferSize = 0;
+		bool requestWritePath = false;
 	};
 }


### PR DESCRIPTION
Fix for issue #38. 

- write_current_path cannot be called during work_response.
- output atom sequence frame is not popped.