### PR TITLE
invalid state.save() results, option  1.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(NeuralAmpModelerLv2 VERSION 0.1.0)
+project(NeuralAmpModelerLv2 VERSION 0.1.1)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(NeuralAmpModelerLv2 VERSION 0.1.1)
+project(NeuralAmpModelerLv2 VERSION 0.1.0)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 

--- a/src/nam_lv2.cpp
+++ b/src/nam_lv2.cpp
@@ -39,7 +39,10 @@ static void connect_port(LV2_Handle instance, uint32_t port, void* data)
   *(reinterpret_cast<void**>(&nam->ports)+port) = data;
 }
 
-static void activate(LV2_Handle) {}
+static void activate(LV2_Handle instance) {
+	static_cast<NAM::Plugin*>(instance)->activate();
+
+}
 
 static void run(LV2_Handle instance, uint32_t n_samples)
 {
@@ -54,7 +57,9 @@ static void run(LV2_Handle instance, uint32_t n_samples)
 	std::feupdateenv(&fe_state);
 }
 
-static void deactivate(LV2_Handle) {}
+static void deactivate(LV2_Handle instance) {
+	static_cast<NAM::Plugin*>(instance)->deactivate();
+}
 
 static void cleanup(LV2_Handle instance)
 {

--- a/src/nam_plugin.cpp
+++ b/src/nam_plugin.cpp
@@ -74,7 +74,7 @@ namespace NAM {
 		return true;
 	}
 
-	::DSP* Plugin::load_model(const char*filename)
+	::DSP* Plugin::load_model(const char* filename)
 	{
 		// runs on non-RT, can block or use [de]allocations
 			
@@ -401,7 +401,7 @@ namespace NAM {
 			if (!nam->activated)
 			{
 				// load the model synchronously.
-				::DSP*model = nullptr;
+				::DSP* model = nullptr;
 				try {
 					model = nam->load_model(msg.path);
 					nam->currentModelPath = msg.path;

--- a/src/nam_plugin.h
+++ b/src/nam_plugin.h
@@ -70,20 +70,23 @@ namespace NAM {
 
 		::DSP* currentModel = nullptr;
 		std::string currentModelPath;
+		bool requestModelPathUpdate = false;
 
 		std::unordered_map<std::string, double> mNAMParams = {};
 
 		Plugin();
 		~Plugin();
 
-		bool initialize(double rate, const LV2_Feature* const* features) noexcept;
-		void process(uint32_t n_samples) noexcept;
 
-		void write_current_path();
+		bool initialize(double rate, const LV2_Feature* const* features) noexcept;
+		void activate();
+		void process(uint32_t n_samples) noexcept;
+		void deactivate();
 
 		static uint32_t options_get(LV2_Handle instance, LV2_Options_Option* options);
 		static uint32_t options_set(LV2_Handle instance, const LV2_Options_Option* options);
 
+		
 		static LV2_Worker_Status work(LV2_Handle instance, LV2_Worker_Respond_Function respond, LV2_Worker_Respond_Handle handle,
 			uint32_t size, const void* data);
 		static LV2_Worker_Status work_response(LV2_Handle instance, uint32_t size, const void* data);
@@ -93,6 +96,9 @@ namespace NAM {
 		static LV2_State_Status restore(LV2_Handle instance, LV2_State_Retrieve_Function retrieve, LV2_State_Handle handle, uint32_t flags,
 			const LV2_Feature* const* features);
 
+	private:
+		::DSP*load_model(const char*filename);
+		void write_current_path();
 	private:
 		struct URIs {
 			LV2_URID atom_Object;
@@ -118,5 +124,6 @@ namespace NAM {
 		float inputLevel = 0;
 		float outputLevel = 0;
 		int32_t maxBufferSize = 0;
+		bool activated = false;
 	};
 }

--- a/src/nam_plugin.h
+++ b/src/nam_plugin.h
@@ -97,7 +97,7 @@ namespace NAM {
 			const LV2_Feature* const* features);
 
 	private:
-		::DSP*load_model(const char*filename);
+		::DSP* load_model(const char* filename);
 		void write_current_path();
 	private:
 		struct URIs {


### PR DESCRIPTION
Addresses issue #36.

- state restore loads the model synchronously if not activated.
- State restore should clear the model if a model path isn't
  provided in state.
-  Avoid error messages in ardour when loading empty
  state.
- load errors clear the filename, instead of leaving the
  previous filename, while not having a model.

Reflects discussions with @falkTX  . Improved handling of "" in state save/restore, reflecting bugs in Ardour and PiPedal.

Clearing the filename on error has not been discussed, but it seems  preferable to leaving the old filename, but having no model.