### PR TITLE
Pre-run new models for at least 4096 samples

### DIFF
--- a/src/nam_plugin.cpp
+++ b/src/nam_plugin.cpp
@@ -122,8 +122,12 @@ namespace NAM {
 							float* buffer = new float[numSamples];
 
 							std::unordered_map<std::string, double> params = {};
-							model->process(&buffer, &buffer, 1, numSamples, 1.0, 1.0, params);
-							model->finalize_(numSamples);
+							for (int32_t i=0; i<4096; i += numSamples)
+							{
+								std::memset(buffer, 0, sizeof(float)*numSamples);
+								model->process(&buffer, &buffer, 1, numSamples, 1.0, 1.0, params);
+								model->finalize_(numSamples);
+							}
 
 							delete[] buffer;
 						}


### PR DESCRIPTION
While playing with NAM we noticed a few audio pops when changing models.
The NAM core side already has an "anti-pop" feature of sorts, but it is not applied for all model types and not in the same way.
Since we already pre-run the plugin in order to force the correct buffer size, we can run it a few more times to get rid of the initial pops.
The 4096 comes from checking NAM code where 4000 is used, and 4096 aligns nicely close to it as a power of 2 (which will be typical for buffer sizes in hosts)
