### PR TITLE
ARM Cortex-A72/Pi 4, and ARM Cortex-A76/Pi 5 compiler options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED OFF)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+option(A72_OPTIMIZATION "Optimize for cortex-a72/Pi4 (arm64 builds only)" ON)
+option(A76_OPTIMIZATION "Optimize for cortex-a76/Pi5 (arm64 builds only)" OFF)
+
+
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	include_directories(SYSTEM /usr/local/include)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -18,6 +22,22 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 else()
 	message(FATAL_ERROR "Unrecognized Platform!")
 endif()
+
+# Compiler flags for aarch64 Pi 4/5 optimizations
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" AND (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
+
+    set(CMAKE_CXX_FLAGS_RELEASE  "-O3 -ffast-math -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -ffast-math -g -DNDEBUG")
+
+    if (A76_OPTIMIZATION)
+        message(STATUS "Using Cortex-A76/Pi 5 optimizations")
+        add_compile_options("-mcpu=cortex-a76" "-mtune=cortex-a76")
+    elseif (A72_OPTIMIZATION)
+        message(STATUS "Using Cortex-A72/Pi 4 optimizations")
+        add_compile_options("-mcpu=cortex-a72" "-mtune=cortex-a72")
+    endif()
+endif()
+
 
 set(NAM_LV2_ID http://github.com/mikeoliphant/neural-amp-modeler-lv2)
 


### PR DESCRIPTION
Provides better compiler optimization flags for ARM Cortex-A72/Pi 4, and ARM Cortext-A76/Pi 5.

The A72 optimizations provide about a 15% performance improvement on a Pi 4 compared to your current build. The A76 optimizations are more interesting. As reported by a remote colleague (I don't have a pi 5), the optimizations allow 16 simultaneous instances to run on a Pi5 (PiPedal hosted), instead of 8 instances. (No buffering, 128x3 unfortunately, but no reason to think that it won't also work (or even work slightly better) at 64x3). Informally,  a 2x speed improvement compared to your current build with current optimization flags (which are currently CMake defaults on aarch64).  Dramatic and very significant! 

Optimizations are conditioned on two new CMake Options in the root makefile.

    option(A72_OPTIMIZATION "Optimize for cortex-a72/Pi4 (arm64 builds only)" ON)
    option(A76_OPTIMIZATION "Optimize for cortex-a76/Pi5 (arm64 builds only)" OFF)

Both can be provided on the build command line as usual. e.g: 

   cmake etc etc ... -D A72_OPTIMIZATION 

Compiler flags have to be applied in the root `CMakeLists.txt` file so that all of your deps build with the correct flags. 

I went back and forth on whether the A72 optimizations should be on or off by default. I settled on ON, because optimizing for A72 is probably the Right Thing To Do by default when building for aarch64. Your discretion as to whether you think that's right or not.

For the A72/Pi 4, improvements are (probably) attributable to the addition of -ffast-math, and to use of correct cache-line size definitions which actually make a measurable improvement to Eigen matrix multiplication performance, and better instruction scheduling for the A72 execution unit. The resulting binary will run on any ARM Cortex 8.1a processor, but will be mis-tuned for lesser Cortex 8.1a processors. 

The A76/Pi 5  improvements are probably mainly attributable to brand new instructions on ARM Cortex 8.2a processors, that are specifically designed to do fast matrix multiplies. There are lesser improvements from --ffast-math, better instruction scheduling, and correct cache-line size definitions (twice the L1-cache compared to an A72, which would make a big difference when doing a matrix multiply). Binaries will run on any ARM Cortex 8.2a processor, but will be mis-tuned on lesser processors in the family.

The optimizations have been lightly tested in your build, but heavily tested on a forthcoming release of TooB Nam which switches over to your NeuralAudio library , and abandons its previous optimizations. My current TooB NAM dev build uses these compiler flags applied to your NeuralAudio library. I have not explicitly tested your plugin on a Pi 5, but it will get the same performance boost that TooB NAM gets. Out of caution, you may want to verify that the 2x figure is correct if you have the hardware to do so.

I'm not sure how best to document the new options. I THINK Pi 4 and Pi 5 users will respond to "A72" and "A76", and that users of cousins of the Pi Family (Orange Pi, Neoverse-based Pi-Like things, a variety of other flavors and relatives) will also know enough to know that A72 and A76 improvements will also give them benefits on their particular flavor of Pi. (A76s are fairly common in Pi-Like things, I think).

Congratulations on NeuralAudio. Having done that optimization on NAM Core code (fixed-size matrices), for the TooB project, I know exactly how difficult and precise that work is, from first-hand experience. And your implementation is MUCH tidier than mine.  And it addresses all the pain pain points of NAM Core integration. It is a really fine piece of work! I am frankly, in awe of what you have done.

If I can ever return favors, please let me know. Or if you have development tasks on NeuralAudio you feel like delegating to someone who is already familiar with fundamentals of NeuralAudio code, feel free to ping me. Not like I'm short of things to do; but I do feel a duty to contribute if I can do so usefully. 

And you really need to know (if you don't) that  2x performance improvements on Pi 5 is both astonishing, and game changing. It completely changes the way NAM will be used on Pi 5s, where you can now afford to replace ALL of your non-linear effect pedals (Overdrive distortion pedals, compressors, a strange and beautiful NAM emulation of a Fender Spring Reverb that should not work at all but does, ...), and carelessly use split amp models, e.g. Front half of a vintage DeVille + a full 3 knob Fender Tone stack + the back half of a vintage Deville = a NAM-driven model of a Fender DeVille with full 3 knob tone controls. Or use mixed outputs from two or more amp models, .... or... or.. I'm not sure what life looks like in x64 world; but on a Pi 5 that really does change EVERYTHING!

And thank you ESPECIALLY for having provided the NeuralAudio library under an MIT license! 

Best regards,

Robin Davies
Pipedal 
TooB Plugins Project


 
