### PR TITLE
Add option to bypass model processing on silence

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,6 @@ After building, the plugin will be in **build/neural_amp_modeler.lv2**.
 
 ```-DUSE_NATIVE_ARCH=ON```: If you have a relatively modern x64 processor, you can pass ```-DUSE_NATIVE_ARCH=ON``` on your cmake command line to enable certain processor-specific optimizations.
 
+```-DSMART_BYPASS_ENABLED=ON```: If enabled, this will bypass model processing if input has been silent (below -100 dB by default) for a sufficient number of samples (determined by the model's receptive field size).
+
 Also see the [NeuralAudio CMake options](https://github.com/mikeoliphant/NeuralAudio#cmake-options) - adding these to your neural-amp-modeler-lv2 cmake will pass them to the NeuralAudio build.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,12 @@ if (DISABLE_DENORMALS)
 	add_definitions(-DDISABLE_DENORMALS)
 endif (DISABLE_DENORMALS)
 
+option(SMART_BYPASS_ENABLED "Enable auto-bypass on silence" OFF)
+
+if (SMART_BYPASS_ENABLED)
+	add_definitions(-DSMART_BYPASS_ENABLED)
+endif (SMART_BYPASS_ENABLED)
+
 set_target_properties(neural_amp_modeler
 	PROPERTIES
 	CXX_VISIBILITY_PRESET hidden

--- a/src/nam_plugin.h
+++ b/src/nam_plugin.h
@@ -80,6 +80,7 @@ namespace NAM {
 
 		bool initialize(double rate, const LV2_Feature* const* features) noexcept;
 		void set_max_buffer_size(int size) noexcept;
+		void activate() noexcept;
 		void process(uint32_t n_samples) noexcept;
 
 		void write_current_path();
@@ -122,6 +123,6 @@ namespace NAM {
 		int32_t maxBufferSize = 512;
 		float bypassThresholdLinear = 0;
 		uint32_t silentSamples = 0;
-		bool smartBypassed = false;
+		bool smartBypassed = true;
 	};
 }

--- a/src/nam_plugin.h
+++ b/src/nam_plugin.h
@@ -120,5 +120,8 @@ namespace NAM {
 		float inputLevel = 0;
 		float outputLevel = 0;
 		int32_t maxBufferSize = 512;
+		float bypassThresholdLinear = 0;
+		uint32_t silentSamples = 0;
+		bool smartBypassed = false;
 	};
 }


### PR DESCRIPTION
If enabled (it is currently disabled by default), this will bypass model processing after a sufficient number of samples (determined by the model's receptive field) have been received.